### PR TITLE
Run browserify on vue files only if elixir/gulp use the watch task

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -14,5 +14,7 @@ elixir(function(mix) {
 
   mix.browserify('./app/app.js');
 
-  mix.task('browserify', './app/**/**.vue');
+  if (elixir.isWatching()) {
+      mix.task('browserify', './app/**/**.vue');
+  }
 });


### PR DESCRIPTION
For prevent errors on running `gulp` and `gulp --production` I put a condition on gulpfile for execute only if task is watch