### PR TITLE
Fix notifications behaviour

### DIFF
--- a/client/app/notification.js
+++ b/client/app/notification.js
@@ -13,15 +13,21 @@ let notification = new Vue({
 
   methods: {
     songPlayed () {
-      this.notify(
-          `♫ ${this.currentTrack.title}`,
-          `By: ${this.currentTrack.username} on ${this.currentTrack.genre}`
-      );
+      let vm = this;
+      let oldTrackTitle = vm.currentTrack.title;
+      setTimeout(function () {
+        if (vm.$store.state.player.currentTrack.title === oldTrackTitle) {
+          vm.notify(
+              `♫ ${vm.currentTrack.title}`,
+              `By: ${vm.currentTrack.username} on ${vm.currentTrack.genre}`
+          );
+        }
+      }, 5000);
     },
 
     notify(title, body, silent = true, icon = '../assets/img/icon.png') {
       Notification.requestPermission();
-      let n =  new Notification(
+      return new Notification(
         title,
         {
           icon,
@@ -29,8 +35,6 @@ let notification = new Vue({
           silent
         }
       );
-
-      setTimeout(n.close.bind(n), 5000);
     }
   }
 });


### PR DESCRIPTION
Notifications are triggered as soon as the music was played , resulting in a large number of them if the user click next / prev multiple times

Now the notification are spawned inside a setTimeout callback, and after 5s if the currentTrack from store was changed, the notification not will be triggered

Refer to [0.1.2 cloudradioo-app](https://github.com/devfake/cloudradioo-app/releases/tag/0.1.2)
